### PR TITLE
Improve instructions for people less familiar with Git & GH

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ or
   git status
 ```
 
-- The response should be like this - 
+- The response should be like this:
 
 ```
 On branch <name-of-your-branch>

--- a/README.md
+++ b/README.md
@@ -18,39 +18,39 @@ Repo for you to raise a Pull Request for practice.
 
 **Just add your name to the alphabetical list and optionally, a link to your GitHub account (In alphabetical order below your letter too)**
 
-## How to contribute
+## How to contribute (overall process)
 
-1. Fork the project
+1. Fork the project, using the gray `Fork` button in the top right of this page
 2. Make any changes in your forked repo
-3. On this repo, click `Pull Requests` and raise a `Pull Request` selecting your fork on the right drop down
+3. On this repo, click `Pull Requests` (which is the third option at the top of this page after the options `Code` and `Issues`) and raise a Pull Request by clicking the green `New Pull Request` button and selecting your fork from the right drop down field.
 
 Questions can be asked by raising an `Issue`.
 
-## How to clone repo and make changes locally
+## How to clone repo and make changes locally after forking
 
-- Click on the clone button (green in colour). This gives you a copy of the project. It's now yours to play around with.
+- Click on the  green `Code` button, then either the HTTPS or SSH option and click the icon to copy the URL. This will give you a copy of the project, so you can play around with it locally on your computer.
 
-- Using Git on your local machine. Do this to download the forked copy of this repo to your computer.
+- Using Git on your local machine and paste in the URL. Do this to download the forked copy of this repo to your computer.
 
 ```
   git clone https://github.com/yourGithubUsername/hacktoberfest-practice.git
 ```
 
-- switch to the cloned folder. This can be done with Gitbash or the integrated terminal in the VSCode editor.
+- Switch to the cloned folder. This can be done with Gitbash or the integrated terminal in the VSCode editor.
 
 ```
   cd hacktoberfest-practice
 ```
 
-- Make a new branch. Your name would make a good branch because it's unique.
+- Make a new branch. Your username would make a good branch because it's unique.
 
 ```
-  git checkout -b <name of new branch>
+  git checkout -b <name-of-new-branch>
 ```
 
 - Open the `README.md` file
 
-- #### Add your name to the section ([Hactoberfest community](https://github.com/EddieHubCommunity/hacktoberfest-practice#hacktoberfest-community)) that is headed with your first initial. Then, add your name in alphabetical order of the second letter in your name. If the second letters are the same, order it in alphabetical order of the third, and so on. Next to it, add the link to your github username page.
+- #### Add your name to the section ([Hactoberfest community](https://github.com/EddieHubCommunity/hacktoberfest-practice#hacktoberfest-community)) that is headed with your first initial. Then, add your name in alphabetical order of the second letter in your name. If the second letters are the same, order it in alphabetical order of the third, and so on. Next to it, add the link to your github username page. Then save your changes
 
 - For example ,
   `- [Full Name](https://github.com/your-username)`
@@ -79,10 +79,17 @@ or
   git status
 ```
 
+- The response should be like this - 
+
+```
+On branch <name-of-your-branch>
+nothing to commit, working tree clean
+```
+
 - Pushing your repository to GitHub.
 
 ```
-  git push origin <name of your branch>
+  git push origin <name-of-your-branch>
 ```
 
 or
@@ -92,9 +99,16 @@ or
   git push -u origin main
 ```
 
-- Navigate to your fork, on the top of the files section you'll notice a new section containing, a contribute button!
-- Click on the contribute button, it will open a drop down, click the pull request button on the drop down.
-  Note: A pull request allows your changes to be merged with the original project.
+In case you get an error message like the one below, its likely you forgot to fork the repo before cloning it. To fix this, its best to start over with the How to Contribute section above, and fork the project repo first.
+```
+ERROR: Permission to EddieHubCommunity/hacktoberfest-practice.git denied to <your-github-username>.
+fatal: Could not read from remote repository.
+Please make sure you have the correct access rights and the repository exists.
+```
+
+- On the GitHub website, navigate to your forked repo - on the top of the files section you'll notice a new section containing a `Compare & Pull Request` button!
+- Click on that button and this will load a new page, comparing the local branch in your forked repo, against the main branch in the EddieHub Hacktoberfest repo. Accept the default values in the drop down boxes and click the green `Create Pull Request` button. The next page will run a check and a bot should give you a success message.  
+  Note: A pull request allows your changes to be merged with the original project repo.
 
 - Wait for your changes to be merged.
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Hurray! You successfully made a contribution! 🎉
   - [Darsh Gupta](https://github.com/DarshGupta1910)
   - [Dave Bhandari](https://github.com/Davekibh)
   - [David Leal](https://github.com/Panquesito7)
+  - [Davin S](https://github.com/davin2020)
   - [Debbie D](https://github.com/hellodeborahuk)
   - [Deepak B](https://github.com/sbdeepu09)
   - [Deepak Hagadur Bheemaraju](https://github.com/deepakhb2)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Questions can be asked by raising an `Issue`.
 
 - Open the `README.md` file
 
-- #### Add your name to the section ([Hactoberfest community](https://github.com/EddieHubCommunity/hacktoberfest-practice#hacktoberfest-community)) that is headed with your first initial. Then, add your name in alphabetical order of the second letter in your name. If the second letters are the same, order it in alphabetical order of the third, and so on. Next to it, add the link to your github username page. Then save your changes
+- #### Add your name to the section ([Hactoberfest community](https://github.com/EddieHubCommunity/hacktoberfest-practice#hacktoberfest-community)) that is headed with your first initial. Then, add your name in alphabetical order of the second letter in your name. If the second letters are the same, order it in alphabetical order of the third, and so on. Next to it, add the link to your github username page. Then save your changes. 
 
 - For example ,
   `- [Full Name](https://github.com/your-username)`

--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ Please make sure you have the correct access rights and the repository exists.
 ```
 
 - On the GitHub website, navigate to your forked repo - on the top of the files section you'll notice a new section containing a `Compare & Pull Request` button!
-- Click on that button and this will load a new page, comparing the local branch in your forked repo, against the main branch in the EddieHub Hacktoberfest repo. Accept the default values in the drop down boxes and click the green `Create Pull Request` button. The next page will run a check and a bot should give you a success message.  
-  Note: A pull request allows your changes to be merged with the original project repo.
+
+- Click on that button and this will load a new page, comparing the local branch in your forked repo, against the main branch in the EddieHub Hacktoberfest repo. Accept the default values in the drop down boxes and click the green `Create Pull Request` button. After creating the PR (Pull Request) our GitHub Actions workflow will add a welcome message to your PR.
+Note: A pull request allows your changes to be merged with the original project repo.
 
 - Wait for your changes to be merged.
 


### PR DESCRIPTION
Would like to suggest some changes to make the instruction easier to follow for people less familiar with Git & GitHub -

- making the "Fork before Cloning" instruction clearer, and where the Fork and Pull Request options are
- naming the buttons as seen in the current version of GitHub eg `Code` instead of `Clone`, `Compare & Pull Request` instead of `Contribute`
- added expected result of `git status`
- added the `permission denied` error message in case new users see it
- added hyphens to branch names for consistency, and so users are less likely to create names with spaces